### PR TITLE
feat: 新增武汉/湖北居民充电分时电价模板

### DIFF
--- a/grafana/dashboards/zh-cn/tou-config.json
+++ b/grafana/dashboards/zh-cn/tou-config.json
@@ -1080,6 +1080,11 @@
                 "id": "jiangsu",
                 "value": "jiangsu",
                 "label": "江苏/南京"
+              },
+              {
+                "id": "wuhan",
+                "value": "wuhan",
+                "label": "武汉"
               }
             ]
           },

--- a/sql/install-tou.sql
+++ b/sql/install-tou.sql
@@ -293,6 +293,14 @@ BEGIN
       (target_geofence_id, 13, 15, 0.6683, '夏尖', '2026-07-01', '2026-08-31'),
       (target_geofence_id, 18, 21, 0.6683, '冬尖', '2026-12-01', '2027-02-28');
     inserted := 4;
+  WHEN 'wuhan', '武汉' THEN
+    INSERT INTO tou_rates (geofence_id, hour_start, hour_end, rate, label) VALUES
+      (target_geofence_id, 23, 7,  0.43, '谷'),
+      (target_geofence_id, 7,  17, 0.58, '平'),
+      (target_geofence_id, 17, 20, 0.68, '峰'),
+      (target_geofence_id, 20, 22, 0.78, '尖'),
+      (target_geofence_id, 22, 23, 0.68, '峰');
+    inserted := 5;
   ELSE
     inserted := 0;
   END CASE;
@@ -909,7 +917,8 @@ CREATE OR REPLACE FUNCTION list_city_templates() RETURNS TABLE (
     ('shenzhen',  '深圳'),
     ('guangzhou', '广州'),
     ('zhejiang',  '浙江/杭州'),
-    ('jiangsu',   '江苏/南京（含夏冬尖峰）')
+    ('jiangsu',   '江苏/南京（含夏冬尖峰）'),
+    ('wuhan',     '武汉')
   ) AS t(city_id, display_name);
 $$ LANGUAGE sql IMMUTABLE;
 


### PR DESCRIPTION
基于鄂发改价管〔2023〕320号：

时段与电价（以居民合表电价 0.58 元/度为基准）：
- 谷段 23:00-7:00  0.43 元/度（-0.15）
- 平段  7:00-17:00 0.58 元/度（基准价）
- 峰段 17:00-20:00、22:00-23:00  0.68 元/度（+0.10）
- 尖段 20:00-22:00 0.78 元/度（+0.20） 无季节性尖峰，全年统一。

政策文件：https://fgw.hubei.gov.cn/fbjd/zc/zcwj/tz/202411/t20241115_5415329.shtml 政策解读：https://fgw.hubei.gov.cn/fgjj/ztzl/zl/2022/hqzchfwzl/zcjd/wzjd/202311/t20231123_4964168.shtml

Closes #26